### PR TITLE
fish-shell support

### DIFF
--- a/misc/fish/README.md
+++ b/misc/fish/README.md
@@ -1,0 +1,168 @@
+## Installation
+
+You should get binaries in advance (see [README.md](https://github.com/b4b4r07/history/blob/master/README.md#installation)). Then you can get fish-shell support with your plugin manager. 
+
+- Install with [fundle](https://github.com/tuvistavie/fundle)
+
+  Add the following in your config.fish.
+
+  ```fish
+  fundle plugin 'b4b4r07/history' --path 'misc/fish'
+  fundle init
+  ```
+
+- Install with [fresco](https://github.com/masa0x80/fresco)
+
+  Run the following command.
+  ```fish
+  fresco b4b4r07/history
+  ```
+
+- Install with [fisherman](https://github.com/fisherman/fisherman)
+
+  You cannot choose a specific directory in a repository to load as a fish plugin.
+  But you can load the local directory misc/fish as a plugin.
+  If you get the binaries with `go get`, run the following command.
+
+  ```
+  fisher $GOPATH/src/github.com/b4b4r07/history/misc/fish
+  ```
+
+## Usage
+
+You should specify some enviroment variables for using this tool.
+
+<details>
+<summary><strong><code>fish_history_cmd_name</code></strong></summary>
+
+
+
+It should be used as an alias  of `command history`. Completions are genereted for this alias. 
+
+</details>
+
+<details>
+<summary><strong><code>fish_history_filter_options</code></strong></summary>
+
+
+
+It should be set `history search` option. See also `command history help search`.
+
+</details>
+
+<details>
+<summary><strong><code>fish_history_auto_sync</code></strong></summary>
+
+
+
+Example:
+
+```fish
+set -U fish_history_auto_sync true
+```
+
+If you set sync option (for more datail, see and run `history config`)
+
+</details>
+
+<details>
+<summary><strong><code>fish_history_auto_sync_interval</code></strong></summary>
+
+
+
+Example:
+
+```zsh
+set -U fish_history_auto_sync_intareval "1h"
+```
+
+</details>
+
+## Keybindings
+
+These are functions to use for user specified keybindings.
+To save custom keybindings, put the bind statements into your `fish_user_key_bindings` function.
+
+<details>
+<summary><strong><code>__history_keybind_get</code></strong></summary>
+
+
+
+You can set keybind for getting history.
+
+Example:
+
+```fish
+bind \cr __history_keybind_get
+```
+
+</details>
+
+<details>
+<summary><strong><code>__history_keybind_get_all</code></strong></summary>
+
+Ignore `fish_history_filter_options` and search all history.
+
+Example:
+
+```fish
+bind \cr\ca __fish_history_keybind_get_all
+```
+
+
+</details>
+
+<details>
+<summary><strong><code>__history_keybind_get_by_dir</code></strong></summary>
+
+It's equals to `__fish_history_keybind_get` with `fish_history_filter_options="--filter-branch --filter-dir"`.
+
+</details>
+
+<details>
+<summary><strong><code>__history_keybind_arrow_up</code></strong></summary>
+
+Example:
+
+```fish
+bind \cp __history_keybind_arrow_up
+```
+
+</details>
+
+<details>
+<summary><strong><code>__history_keybind_arrow_down</code></strong></summary>
+
+Example:
+
+```fish
+bind \cn __history_keybind_arrow_down
+```
+
+</details>
+
+---
+
+Anyway, if you want to use it immediately please run the following commands:
+
+```fish
+set -U fish_history_cmd_name hs    # as you like
+set -U fish_history_auto_sync true
+set -U fish_history_filter_options "--filter-branch --filter-dir"
+```
+
+Then, add the following statements into the definition of `fish_user_key_bindings` function.
+
+(You can edit and save `fish_user_key_bindings` by `funced fish_user_key_bindings; and funcsave fish_user_key_bindings`.)
+
+```fish
+function fish_user_key_bindings
+
+  bind \cr __fish_history_keybind_get
+  bind \cp __fish_history_keybind_arrow_up
+  bind \cn __fish_history_keybind_arrow_down
+
+end
+```
+
+

--- a/misc/fish/init.fish
+++ b/misc/fish/init.fish
@@ -7,7 +7,7 @@ if test -z "$fish_history_cmd_name"
 end
 
 if test -z "$fish_history_auto_sync"
-    set -g fish_history_auto_sync true
+    set -g fish_history_auto_sync false
 end
 
 if test -z "$fish_history_auto_sync_interval"
@@ -109,7 +109,7 @@ if test "$fish_history_auto_sync" = true
                 and echo $fish_history_auto_sync_interval
                 or echo -1)
 
-        command history sync --ask --diff=100 --interval="$sync_interval" ^/dev/null
+        command history sync --diff=100 --interval="$sync_interval" ^/dev/null
 
         set -l status_code $status
         set -l after (date +%s)

--- a/misc/fish/init.fish
+++ b/misc/fish/init.fish
@@ -1,0 +1,23 @@
+#
+# Configurations
+#
+
+if test -z "$fish_history_cmd_name"
+    set -g fish_history_cmd_name history
+end
+
+if test -z "$fish_history_auto_sync"
+    set -g fish_history_auto_sync true
+end
+
+if test -z "$fish_history_auto_sync_interval"
+    set -g fish_history_auto_sync_interval 1h
+end
+
+if test -z "$fish_history_columns_get_all"
+    set -g fish_history_columns_get_all "{{.Time}}, {{.Status}},({{.Base}}:{{.Branch}})"
+end
+
+if test -z "$fish_history_filter_options"
+    set -g fish_history_filter_options "--filter-dir --filter-branch" 
+end

--- a/misc/fish/init.fish
+++ b/misc/fish/init.fish
@@ -21,3 +21,66 @@ end
 if test -z "$fish_history_filter_options"
     set -g fish_history_filter_options "--filter-dir --filter-branch" 
 end
+
+#
+# Alias
+#
+
+function $fish_history_cmd_name -d "enhanced history for your shell"
+    command history $argv
+end
+
+#
+# Completions
+#
+
+## erase old completions
+complete -ec $fish_history_cmd_name
+
+## subcommands
+complete -xc $fish_history_cmd_name -n '__fish_use_subcommand' -a 'add' -d 'Add new history'
+complete -xc $fish_history_cmd_name -n '__fish_use_subcommand' -a 'config' -d 'Config the setting file'
+complete -xc $fish_history_cmd_name -n '__fish_use_subcommand' -a 'edit' -d 'Edit your history file directly'
+complete -xc $fish_history_cmd_name -n '__fish_use_subcommand' -a 'list' -d 'List the history'
+complete -xc $fish_history_cmd_name -n '__fish_use_subcommand' -a 'search' -d 'Search the command from the history file'
+complete -xc $fish_history_cmd_name -n '__fish_use_subcommand' -a 'delete' -d 'Delete the record from history file'
+complete -xc $fish_history_cmd_name -n '__fish_use_subcommand' -a 'sync' -d 'Sync the history file with gist'
+complete -xc $fish_history_cmd_name -n '__fish_use_subcommand' -a 'help' -d 'Show help for any command'
+
+## global options
+complete -xc $fish_history_cmd_name -n '__fish_no_arguments' -s h -l help -d 'Show the help message'
+complete -xc $fish_history_cmd_name -n '__fish_no_arguments' -s v -l version -d 'Show the version and exit'
+
+## options for add
+complete -xc $fish_history_cmd_name -n '__fish_seen_subcommand_from add' -s h -l help -d 'Show the help message'
+complete -xc $fish_history_cmd_name -n '__fish_seen_subcommand_from add' -l branch -d 'Set branch'
+complete -xc $fish_history_cmd_name -n '__fish_seen_subcommand_from add' -l command -d 'Set command'
+complete -xc $fish_history_cmd_name -n '__fish_seen_subcommand_from add' -l dir -d 'Set dir'
+complete -xc $fish_history_cmd_name -n '__fish_seen_subcommand_from add' -l status -d 'Set status'
+
+## options for search/list/delete
+for cmd in search list delete
+    set -l Cmd (string sub -l 1 $cmd | tr '[:lower:]' '[:upper:]')(string sub -s 2 $cmd)
+
+    complete -xc $fish_history_cmd_name -n "__fish_seen_subcommand_from $cmd" -s h -l help -d "Show the help and exit"
+    complete -xc $fish_history_cmd_name -n "__fish_seen_subcommand_from $cmd" -s b -l filter-branch -d "$Cmd with branch"
+    complete -xc $fish_history_cmd_name -n "__fish_seen_subcommand_from $cmd" -s d -l filter-dir -d "$Cmd with dir"
+    complete -xc $fish_history_cmd_name -n "__fish_seen_subcommand_from $cmd" -s p -l filter-hostname -d "$Cmd with hostname"
+    complete -xc $fish_history_cmd_name -n "__fish_seen_subcommand_from $cmd" -s q -l query -d "$Cmd with query"
+    complete -xc $fish_history_cmd_name -n "__fish_seen_subcommand_from $cmd" -s c -l filter-branch -d "$Cmd columns with options"
+end
+
+## options for sync 
+complete -xc $fish_history_cmd_name -n '__fish_seen_subcommand_from sync' -s h -l help -d 'Show the help message'
+complete -xc $fish_history_cmd_name -n '__fish_seen_subcommand_from sync' -l interval -d 'Sync with the interval'
+complete -xc $fish_history_cmd_name -n '__fish_seen_subcommand_from sync' -l diff -d 'Sync if the diff exceeds a certain number'
+complete -xc $fish_history_cmd_name -n '__fish_seen_subcommand_from sync' -l ask -d 'Sync after the confirmation'
+
+## options for edit
+complete -xc $fish_history_cmd_name -n '__fish_seen_subcommand_from edit' -s h -l help -d 'Show the help message'
+
+## options for config
+and set -l keys (command history config --keys)
+complete -xc $fish_history_cmd_name -n '__fish_seen_subcommand_from config' -s h -l help -d 'Show the help message'
+complete -xc $fish_history_cmd_name -n '__fish_seen_subcommand_from config' -l get -a "$keys" -d 'Get the config value'
+complete -xc $fish_history_cmd_name -n '__fish_seen_subcommand_from config' -l keys -d 'Get the config keys'

--- a/misc/fish/init.fish
+++ b/misc/fish/init.fish
@@ -167,3 +167,54 @@ function __history_substring_history_down
         commandline $__history_substring_search_query
     end
 end
+
+#
+# Keybindings
+#
+
+function __history_keybind_get
+    set -l buf (command history search $fish_history_filter_options \
+        --query (commandline -c))
+
+    test -n "$buf"
+    and commandline $buf
+
+    commandline -f repaint
+end
+
+function __history_keybind_get_by_dir
+    set -l buf (command history search \
+        --filter-dir \
+        --filter-branch \
+        --query (commandline -c))
+
+    test -n "$buf"
+    and commandline $buf
+
+    commandline -f repaint
+end
+
+function __history_keybind_get_all
+    set -l opt
+    test -n "$fish_history_columns_get_all"
+    and set opt "--columns $fish_history_columns_get_all"
+
+    set -l buf (command history search $opt --query (commandline -c))
+
+    test -n "$buf"
+    and commandline $buf
+
+    commandline -f repaint
+end
+
+function __history_keybind_arrow_up
+    __history_substring_search_begin
+    __history_substring_history_up
+    __history_substring_search_end
+end
+
+function __history_keybind_arrow_down
+    __history_substring_search_begin
+    __history_substring_history_down
+    __history_substring_search_end
+end


### PR DESCRIPTION
Hi, thank you for the nice cli tool!

I wrote some functions and completions for fish-shell.
The differences from the zsh version are the following:

- Add the environment variables `fish_history_cmd_name`. This variable is used as an alias of `command history`. To generate completions, the  command name is required and this name should be customizable. So I use the environment variable.
- Remove the environment variables  corresponding to `ZSH_HISTORY_KEYBIND_*`.  Keybinding through environment variables are not a common way for fish shell.
- Change the default value of `fish_history_auto_sync` (corresponding to `ZSH_HISTORY_AUTO_SYNC`) into `false`. In fish shell, function called by the event handler cannot receive user's input. So auto-sync runs without confirmation.
- Programmable highlighting is not available in fish shell, so matched strings are not highlighted at substring search.
