### PR TITLE
Fix the fish-shell support

### DIFF
--- a/misc/fish/README.md
+++ b/misc/fish/README.md
@@ -11,13 +11,6 @@ You should get binaries in advance (see [README.md](https://github.com/b4b4r07/h
   fundle init
   ```
 
-- Install with [fresco](https://github.com/masa0x80/fresco)
-
-  Run the following command.
-  ```fish
-  fresco b4b4r07/history
-  ```
-
 - Install with [fisherman](https://github.com/fisherman/fisherman)
 
   You cannot choose a specific directory in a repository to load as a fish plugin.

--- a/misc/fish/README.md
+++ b/misc/fish/README.md
@@ -151,9 +151,9 @@ Then, add the following statements into the definition of `fish_user_key_binding
 ```fish
 function fish_user_key_bindings
 
-  bind \cr __fish_history_keybind_get
-  bind \cp __fish_history_keybind_arrow_up
-  bind \cn __fish_history_keybind_arrow_down
+  bind \cr __history_keybind_get
+  bind \cp __history_keybind_arrow_up
+  bind \cn __history_keybind_arrow_down
 
 end
 ```

--- a/misc/fish/init.fish
+++ b/misc/fish/init.fish
@@ -134,7 +134,7 @@ function __history_substring_search_begin
             --filter-branch \
             --filter-dir \
             --columns '{{.Command}}' \
-            --query (string escape -n $buffer))
+            --query "$buffer")
 
         set -g __history_substring_search_matches_count (count $__history_substring_search_matches)
         set -g __history_substring_search_match_index (math $__history_substring_search_matches_count + 1)
@@ -150,11 +150,12 @@ function __history_substring_search_end
 end
 
 function __history_substring_history_up
-    if test "$__history_substring_search_match_index" -gt 0
+    if test "$__history_substring_search_match_index" -gt 1
         set -g __history_substring_search_match_index (math $__history_substring_search_match_index - 1)
         commandline $__history_substring_search_matches[$__history_substring_search_match_index]
     else
-        __history_substring_not_found
+        set -g __history_substring_search_old_buffer (commandline)
+        commandline $__history_substring_search_query
     end
 end
 
@@ -173,8 +174,8 @@ end
 #
 
 function __history_keybind_get
-    set -l buf (command history search $fish_history_filter_options \
-        --query (commandline -c))
+    set -l buf (eval command history search $fish_history_filter_options \
+        --query (commandline -c | string escape))
 
     test -n "$buf"
     and commandline $buf
@@ -183,10 +184,8 @@ function __history_keybind_get
 end
 
 function __history_keybind_get_by_dir
-    set -l buf (command history search \
-        --filter-dir \
-        --filter-branch \
-        --query (commandline -c))
+    set -l buf (eval command history search --filter-dir --filter-branch \
+        --query (commandline -c | string escape))
 
     test -n "$buf"
     and commandline $buf
@@ -195,11 +194,8 @@ function __history_keybind_get_by_dir
 end
 
 function __history_keybind_get_all
-    set -l opt
-    test -n "$fish_history_columns_get_all"
-    and set opt "--columns $fish_history_columns_get_all"
-
-    set -l buf (command history search $opt --query (commandline -c))
+    set -l buf (eval command history search $fish_history_columns_get_all \
+        --query (commandline -c | string escape))
 
     test -n "$buf"
     and commandline $buf

--- a/misc/fish/init.fish
+++ b/misc/fish/init.fish
@@ -145,7 +145,8 @@ function __history_substring_search_begin
 end
 
 function __history_substring_search_end
-    if test $__history_substring_search_match_index -le $__history_substring_search_matches_count
+    if test $__history_substring_search_match_index -ge 0 \
+        -a $__history_substring_search_match_index -le $__history_substring_search_matches_count
         set -g __history_substring_search_result (commandline)
     else
         set -g __history_substring_search_result
@@ -163,12 +164,13 @@ function __history_substring_history_up
         set -g __history_substring_search_match_index (math $__history_substring_search_match_index - 1)
         commandline $__history_substring_search_matches[$__history_substring_search_match_index]
     else
+        set -g __history_substring_search_match_index 0
         commandline $__history_substring_search_query
     end
 end
 
 function __history_substring_history_down
-    if test "$__history_substring_search_match_index" -lt (count $__history_substring_search_matches)
+    if test "$__history_substring_search_match_index" -lt $__history_substring_search_matches_count
         set -g __history_substring_search_match_index (math $__history_substring_search_match_index + 1)
         commandline $__history_substring_search_matches[$__history_substring_search_match_index]
     else

--- a/misc/fish/init.fish
+++ b/misc/fish/init.fish
@@ -15,11 +15,11 @@ if test -z "$fish_history_auto_sync_interval"
 end
 
 if test -z "$fish_history_columns_get_all"
-    set -g fish_history_columns_get_all "{{.Time}}, {{.Status}},({{.Base}}:{{.Branch}})"
+    set -g fish_history_columns_get_all "{{.Time}},{{.Status}},{{.Command}},({{.Base}}:{{.Branch}})"
 end
 
 if test -z "$fish_history_filter_options"
-    set -g fish_history_filter_options "--filter-dir --filter-branch" 
+    set -g fish_history_filter_options --filter-dir --filter-branch 
 end
 
 #
@@ -184,31 +184,31 @@ end
 #
 
 function __history_keybind_get
-    set -l buf (eval command history search $fish_history_filter_options \
-        --query (commandline -c | string escape))
+    set -l buf (command history search $fish_history_filter_options \
+        --query (commandline -c))
 
     test -n "$buf"
-    and commandline $buf
+    and commandline -- $buf
 
     commandline -f repaint
 end
 
 function __history_keybind_get_by_dir
-    set -l buf (eval command history search --filter-dir --filter-branch \
-        --query (commandline -c | string escape))
+    set -l buf (command history search --filter-dir --filter-branch \
+        --query (commandline -c))
 
     test -n "$buf"
-    and commandline $buf
+    and commandline -- $buf
 
     commandline -f repaint
 end
 
 function __history_keybind_get_all
-    set -l buf (eval command history search $fish_history_columns_get_all \
-        --query (commandline -c | string escape))
+    set -l buf (command history search --columns $fish_history_columns_get_all \
+        --query (commandline -c))
 
     test -n "$buf"
-    and commandline $buf
+    and commandline -- $buf
 
     commandline -f repaint
 end

--- a/misc/fish/init.fish
+++ b/misc/fish/init.fish
@@ -142,11 +142,17 @@ function __history_substring_search_begin
 end
 
 function __history_substring_search_end
-    set -g __history_substring_search_result (commandline)
+    if test $__history_substring_search_match_index -le $__history_substring_search_matches_count
+        set -g __history_substring_search_result (commandline)
+    else
+        set -g __history_substring_search_result
+    end
 
     function __history_substring_reset --on-event fish_preexec
         set -g __history_substring_search_result
     end
+
+    commandline -f repaint
 end
 
 function __history_substring_history_up
@@ -154,7 +160,6 @@ function __history_substring_history_up
         set -g __history_substring_search_match_index (math $__history_substring_search_match_index - 1)
         commandline $__history_substring_search_matches[$__history_substring_search_match_index]
     else
-        set -g __history_substring_search_old_buffer (commandline)
         commandline $__history_substring_search_query
     end
 end
@@ -164,7 +169,7 @@ function __history_substring_history_down
         set -g __history_substring_search_match_index (math $__history_substring_search_match_index + 1)
         commandline $__history_substring_search_matches[$__history_substring_search_match_index]
     else
-        set -g __history_substring_search_old_buffer (commandline)
+        set -g __history_substring_search_match_index (math $__history_substring_search_matches_count + 1)
         commandline $__history_substring_search_query
     end
 end

--- a/misc/fish/init.fish
+++ b/misc/fish/init.fish
@@ -93,11 +93,14 @@ function __history_add --on-event fish_postexec
     if test -n $argv
 
         set -l status_code $status
-        set -l last_command $argv
         set -l git_branch (git rev-parse --abbrev-ref HEAD ^/dev/null)
-
-        command history add --command "$last_command" --dir "$PWD" --status "$status_code" --branch "$git_branch"
-
+        
+        for last_command in (string split '\n' -- "$argv")
+            command history add --command "$last_command" \
+                --dir "$PWD" \
+                --status "$status_code" \
+                --branch "$git_branch"
+        end
     end
 end
 

--- a/misc/fish/init.fish
+++ b/misc/fish/init.fish
@@ -162,20 +162,20 @@ end
 function __history_substring_history_up
     if test "$__history_substring_search_match_index" -gt 1
         set -g __history_substring_search_match_index (math $__history_substring_search_match_index - 1)
-        commandline $__history_substring_search_matches[$__history_substring_search_match_index]
+        commandline -- $__history_substring_search_matches[$__history_substring_search_match_index]
     else
         set -g __history_substring_search_match_index 0
-        commandline $__history_substring_search_query
+        commandline -- $__history_substring_search_query
     end
 end
 
 function __history_substring_history_down
     if test "$__history_substring_search_match_index" -lt $__history_substring_search_matches_count
         set -g __history_substring_search_match_index (math $__history_substring_search_match_index + 1)
-        commandline $__history_substring_search_matches[$__history_substring_search_match_index]
+        commandline -- $__history_substring_search_matches[$__history_substring_search_match_index]
     else
         set -g __history_substring_search_match_index (math $__history_substring_search_matches_count + 1)
-        commandline $__history_substring_search_query
+        commandline -- $__history_substring_search_query
     end
 end
 


### PR DESCRIPTION
Hi, I had fixed the previous P-R about a fish-shell support.

- In the previous version, `__fish_history_filter_options` cannot receive multiple options. It is fixed.
- In the previous version, the behavior of __history_keybind_arrow_up and __history_keybind_arrow_down is not appropriate. It is fixed.
- When the command line buffer has multiple lines, each line will be recorded.
-  A plugin manager `fresco` is not available to install misc/fish/init.fish, so remove descriptions from README.md

Please check it. Thank you!