### PR TITLE
Substiture HOME in paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: go
 sudo: false
 go:
-  - 1.7.5
-  - 1.8
+  - "1.8"
+  - "1.9"
+  - "1.10"
   - tip
 os:
   - linux

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -24,7 +24,7 @@ var (
 )
 
 func conf(cmd *cobra.Command, args []string) error {
-	tomlfile := config.Conf.Core.TomlFile
+	tomlfile := config.Conf.Core.TomlFile.Abs()
 	if tomlfile == "" {
 		dir, _ := config.GetDefaultDir()
 		tomlfile = filepath.Join(dir, "config.toml")

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -14,7 +14,7 @@ var editCmd = &cobra.Command{
 }
 
 func edit(cmd *cobra.Command, args []string) error {
-	path := config.Conf.History.Path
+	path := config.Conf.History.Path.Abs()
 	if path == "" {
 		return cli.ErrConfigHistoryPath
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,4 +51,18 @@ func initConf() {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+
+	if histPath := filepath.Dir(config.Conf.History.Path.Abs()); histPath != "" {
+		if _, err := os.Stat(histPath); err != nil {
+			fmt.Printf("Creating directory '%s' for history storage", histPath)
+			os.MkdirAll(histPath, 0700)
+		}
+	}
+
+	if backupPath := config.Conf.History.BackupPath.Abs(); backupPath != "" {
+		if _, err := os.Stat(backupPath); err != nil {
+			fmt.Printf("Creating directory '%s' for backup storage", backupPath)
+			os.MkdirAll(backupPath, 0700)
+		}
+	}
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -58,7 +58,7 @@ func sync(cmd *cobra.Command, args []string) error {
 }
 
 func skipSyncFor(interval time.Duration) bool {
-	file := filepath.Join(filepath.Dir(config.Conf.Core.TomlFile), ".sync")
+	file := filepath.Join(filepath.Dir(config.Conf.History.Path.Abs()), ".sync")
 	f, err := os.OpenFile(file, os.O_RDONLY|os.O_CREATE, 0600)
 	if err != nil {
 		// Doesn't skip if some errors occur

--- a/history/history.go
+++ b/history/history.go
@@ -21,7 +21,7 @@ type History struct {
 
 func Load() (h *History, err error) {
 	var records []Record
-	path := config.Conf.History.Path
+	path := config.Conf.History.Path.Abs()
 	h = &History{Records: Records{}, Path: path}
 
 	file, err := os.Open(path)
@@ -73,9 +73,15 @@ func (h *History) Backup() (err error) {
 		return nil
 	}
 
-	dir, err := config.GetDefaultDir()
-	if err != nil {
-		return
+	dir := ""
+	p := config.Conf.History.BackupPath
+	if p.Abs() != "" {
+		dir = p.Abs()
+	} else {
+		dir, err = config.GetDefaultDir()
+		if err != nil {
+			return err
+		}
 	}
 
 	dir = filepath.Join(dir, ".backup", time.Now().Format("2006/01/02"))

--- a/history/sync.go
+++ b/history/sync.go
@@ -116,7 +116,7 @@ func (h *History) getGistID() (id string, err error) {
 
 	for _, item := range items {
 		for _, file := range item.Files {
-			if *file.Filename == filepath.Base(config.Conf.History.Path) {
+			if *file.Filename == filepath.Base(config.Conf.History.Path.Abs()) {
 				id = *item.ID
 				break
 			}


### PR DESCRIPTION
This commit allow for $HOME to be a valid placeholder in paths in the toml config file.
This will make it easier to maintain a portable / forkable dotfiles version of the config without having to care about hard paths.

In addition, this change introduces a new setting `backup_path` that allows to specify the path where the backups are stored. I'd like to be able to place the backups near to where the actual history is instead of where the config is located and will help keep the dotfiles cleaner as data can not be moved out of `.config`.

