### PR TITLE
Filter status

### DIFF
--- a/cli/screen.go
+++ b/cli/screen.go
@@ -62,6 +62,9 @@ func NewScreen() (s *Screen, err error) {
 		if cc.FilterHostname && cv.Hostname != record.Hostname {
 			continue
 		}
+		if cc.FilterStatus && cv.Status && record.Status != 0 {
+			continue
+		}
 		lines = append(lines, record.Render())
 		records = append(records, record)
 	}

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -25,6 +25,9 @@ func search(cmd *cobra.Command, args []string) error {
 	if config.Conf.Screen.FilterHostname {
 		config.Conf.Var.Hostname = cli.GetHostName()
 	}
+	if config.Conf.Screen.FilterStatus {
+		config.Conf.Var.Status = true
+	}
 
 	screen, err := cli.NewScreen()
 	if err != nil {
@@ -50,6 +53,7 @@ func init() {
 	searchCmd.Flags().BoolVarP(&config.Conf.Screen.FilterDir, "filter-dir", "d", config.Conf.Screen.FilterDir, "Search with dir")
 	searchCmd.Flags().BoolVarP(&config.Conf.Screen.FilterBranch, "filter-branch", "b", config.Conf.Screen.FilterBranch, "Search with branch")
 	searchCmd.Flags().BoolVarP(&config.Conf.Screen.FilterHostname, "filter-hostname", "p", config.Conf.Screen.FilterHostname, "Search with hostname")
+	searchCmd.Flags().BoolVarP(&config.Conf.Screen.FilterStatus, "filter-status", "s", config.Conf.Screen.FilterStatus, "Search with status OK")
 	searchCmd.Flags().StringVarP(&config.Conf.Var.Query, "query", "q", config.Conf.Var.Query, "Search with query")
 	searchCmd.Flags().StringVarP(&config.Conf.Var.Columns, "columns", "c", config.Conf.Var.Columns, "Specify columns with options")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -90,6 +90,7 @@ type ScreenConfig struct {
 	FilterDir      bool     `toml:"filter_dir"`
 	FilterBranch   bool     `toml:"filter_branch"`
 	FilterHostname bool     `toml:"filter_hostname"`
+	FilterStatus   bool     `toml:"filter_status"`
 	Columns        []string `toml:"columns"`
 	StatusOK       string   `toml:"status_ok"`
 	StatusNG       string   `toml:"status_ng"`
@@ -99,6 +100,7 @@ type VarConfig struct {
 	Dir      string
 	Branch   string
 	Hostname string
+	Status 	 bool
 	Query    string
 	Columns  string
 }
@@ -178,6 +180,7 @@ func (cfg *Config) LoadFile(file string) error {
 	cfg.Screen.FilterDir = false
 	cfg.Screen.FilterBranch = false
 	cfg.Screen.FilterHostname = false
+	cfg.Screen.FilterStatus = false
 	cfg.Screen.Columns = []string{"{{.Time}}", "{{.Status}}", "{{.Command}}"}
 	cfg.Screen.StatusOK = " "
 	cfg.Screen.StatusNG = "x"

--- a/misc/zsh/keybind.zsh
+++ b/misc/zsh/keybind.zsh
@@ -4,7 +4,11 @@ __history::keybind::get()
 {
     local buf opt
     # by default, equals to __history::keybind::get_by_dir behavior
-    buf="$(command history search $ZSH_HISTORY_FILTER_OPTIONS --query "$LBUFFER")"
+    cmd="command history search $ZSH_HISTORY_FILTER_OPTIONS"
+    if [[ -n "$LBUFFER" ]]; then
+        cmd="$cmd --query "$LBUFFER""
+    fi
+    buf="$(eval $cmd)"
     if [[ -n $buf ]]; then
         BUFFER="$buf"
         CURSOR=$#BUFFER


### PR DESCRIPTION
This PR include two commit that are somewhat related.

The first commit introduces a new filter for `history search` that when set will only show commands that previously exited with exit code 0.

The second commit addresses a word split issue that results in errors when ZSH_HISTORY_FILTER_OPTIONS contain more that one filter in history get, eg. when `ZSH_HISTORY_FILTER_OPTIONS="--filter-dir --filter-branch"` is set. 