### PR TITLE
Expose ZSH_HISTORY_FILTER_OPTIONS_BY_DIR to allow configuring get_by_dir behavior

### DIFF
--- a/misc/zsh/init.zsh
+++ b/misc/zsh/init.zsh
@@ -62,6 +62,10 @@ fi
 
 if [[ -z $ZSH_HISTORY_FILTER_OPTIONS ]]; then
     # by default, equals to __history::keybind::get_by_dir behavior
+    export ZSH_HISTORY_FILTER_OPTIONS="${ZSH_HISTORY_OPTIONS_BY_DIR}"
+fi
+
+if [[ -z $ZSH_HISTORY_FILTER_OPTIONS_BY_DIR ]]; then
     export ZSH_HISTORY_FILTER_OPTIONS="--filter-dir --filter-branch"
 fi
 

--- a/misc/zsh/keybind.zsh
+++ b/misc/zsh/keybind.zsh
@@ -19,10 +19,11 @@ __history::keybind::get()
 __history::keybind::get_by_dir()
 {
     local buf
-    buf="$(command history search \
-        --filter-dir \
-        --filter-branch \
-        --query "$LBUFFER")"
+    cmd="command history search $ZSH_HISTORY_FILTER_OPTIONS_BY_DIR"
+    if [[ -n "$LBUFFER" ]]; then
+        cmd="$cmd --query "$LBUFFER""
+    fi
+    buf="$(eval $cmd)"
     if [[ -n $buf ]]; then
         BUFFER="$buf"
         CURSOR=$#BUFFER


### PR DESCRIPTION
This allows to configure get_by_dir with additional flags, like `--filter-status`