### PR TITLE
Fix path marshalling when saveing config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,7 +26,7 @@ func (p *Path) UnmarshalText(text []byte) error {
 	return nil
 }
 
-func (p *Path) MarshalText() (text []byte, err error) {
+func (p Path) MarshalText() (text []byte, err error) {
 	return []byte(p.path), nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+    "path/filepath"
+    "io/ioutil"
+	"testing"
+    "os"
+)
+
+func TestMarshalDefaultConfig(t *testing.T) {
+    dir, err := ioutil.TempDir("", "history-test")
+    if err != nil {
+	    t.Error(err)
+    }
+    defer os.RemoveAll(dir)
+    
+    file := filepath.Join(dir, "config.toml")
+
+    // Loading the config for the first time
+    // creates the default and marshals it
+    err = Conf.LoadFile(file)
+    if err != nil {
+        t.Errorf("Failed to create default config file: %v", err) 
+    }
+
+    // Loading the config for the second time
+    // reads it from disk and unmarshals it
+    err = Conf.LoadFile(file)
+    if err != nil {
+        t.Errorf("Failed to load default config file: %v", err) 
+    }
+}
+


### PR DESCRIPTION
The current implementation does not correctly marshal the configuration, generating a broken config file on first run.